### PR TITLE
fix(trie): trie returns invalid string when only the fist character m…

### DIFF
--- a/src/data-structures/trie/trie.ts
+++ b/src/data-structures/trie/trie.ts
@@ -454,7 +454,12 @@ export class Trie<R = any> extends IterableElementBase<string, R, Trie<R>> {
     if (prefix) {
       for (const c of prefix) {
         const nodeC = startNode.children.get(c);
-        if (nodeC) startNode = nodeC;
+        if (nodeC) {
+          startNode = nodeC;
+        } else {
+          // Early return if the whole prefix is not found
+          return [];
+        }
       }
     }
 

--- a/test/unit/data-structures/trie/trie.test.ts
+++ b/test/unit/data-structures/trie/trie.test.ts
@@ -836,6 +836,22 @@ describe('Trie operations', () => {
     expect(words).toEqual(['apple', 'appetizer']);
   });
 
+  it('Get no words when prefix not found, with no match from the first character', () => {
+    trie.add('apple');
+    trie.add('appetizer');
+    trie.add('banana');
+    const words = trie.getWords('cd');
+    expect(words).toEqual([]);
+  });
+
+  it('Get no words when prefix not found, with no match from the second character', () => {
+    trie.add('apple');
+    trie.add('appetizer');
+    trie.add('banana');
+    const words = trie.getWords('ab');
+    expect(words).toEqual([]);
+  });
+
   it('Tree Height', () => {
     trie.add('apple');
     trie.add('banana');


### PR DESCRIPTION
I've added an early return of an empty array, when the _whole_ `prefix` doesn't find a match.
The _whole_ `prefix` should be able to traverse through the nodes.

Fixes #93