### PR TITLE
Fix ESM build

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "build": "npm run build:ecu && npm run build:docs-class",
-    "build:esm": "rm -rf dist/esm && tsc -p tsconfig-esm.json",
+    "build:esm": "rm -rf dist/esm && tsc -p tsconfig-esm.json && node scripts/fix-esm-imports.cjs",
     "build:cjs": "rm -rf dist/cjs && tsc -p tsconfig-cjs.json",
     "build:umd": "tsup",
     "build:ecu": "npm run build:esm && npm run build:cjs && npm run build:umd",

--- a/scripts/fix-esm-imports.cjs
+++ b/scripts/fix-esm-imports.cjs
@@ -1,0 +1,75 @@
+const fs = require("fs");
+const path = require("path");
+
+const ROOT = path.resolve(__dirname, "..", "dist", "esm");
+
+function isRelativeBare(spec) {
+  return (
+    (spec.startsWith("./") || spec.startsWith("../")) &&
+    !spec.endsWith(".js") &&
+    !spec.endsWith(".mjs") &&
+    !spec.endsWith(".cjs") &&
+    !spec.endsWith(".json")
+  );
+}
+
+function resolveTarget(fileDir, spec) {
+  const base = path.resolve(fileDir, spec);
+
+  // Case 1: "./foo.js" exists
+  if (fs.existsSync(base + ".js")) {
+    return spec + ".js";
+  }
+
+  // Case 2: "./foo/index.js" exists
+  const indexPath = path.join(base, "index.js");
+  if (fs.existsSync(indexPath)) {
+    // normalize to POSIX for import strings
+    return spec.replace(/\\/g, "/") + "/index.js";
+  }
+
+  // Could not resolve safely
+  return null;
+}
+
+function processFile(filePath) {
+  if (!filePath.endsWith(".js")) return;
+
+  let code = fs.readFileSync(filePath, "utf8");
+  let changed = false;
+
+  // matches: import ... from "spec"  OR export ... from "spec"
+  const importExportRegex =
+    /(import\s+(?:[^"']+?\s+from\s+)?|export\s+(?:\*|{[^}]*})\s+from\s+)["']([^"']+)["']/g;
+
+  code = code.replace(importExportRegex, (full, prefix, spec) => {
+    if (!isRelativeBare(spec)) return full;
+
+    const dir = path.dirname(filePath);
+    const fixed = resolveTarget(dir, spec);
+    if (!fixed) return full;
+
+    changed = true;
+    return `${prefix}"${fixed}"`;
+  });
+
+  if (changed) {
+    fs.writeFileSync(filePath, code, "utf8");
+  }
+}
+
+function walk(dir) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      walk(full);
+    } else if (entry.isFile()) {
+      processFile(full);
+    }
+  }
+}
+
+if (fs.existsSync(ROOT)) {
+  walk(ROOT);
+}
+


### PR DESCRIPTION
by rewriting imports to include full paths including .js extension, as required by ESM import rules

This is a hacky PR rewriting paths through a small post-build script, and it only affects the ESM build.

(Obviously, a viable alternative would be to use a (heavier) build tool like vite build to take care of this automatically.)